### PR TITLE
Authentication

### DIFF
--- a/draft-westerlund-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-westerlund-tsvwg-dtls-over-sctp-bis.md
@@ -945,7 +945,11 @@ this specification.
 
 ## Authentication and Policy Decisions
 
-   DTLS/SCTP MUST be mutually authenticated. It is RECOMMENDED that
+   DTLS/SCTP MUST be mutually authenticated. Authentication is the process
+   of establishing the identity of a user or system and verifying that
+   the identity is valid. DTLS only provides proof of possession of a key. 
+   DTLS/SCTP MUST perform identity authentication. When certificates are
+   used DTLS/SCTP MUST perform certificate chain validation. It is RECOMMENDED that
    DTLS/SCTP is used with certificate-based authentication.  All
    security decisions MUST be based on the peer's authenticated
    identity, not on its transport layer identity.


### PR DESCRIPTION
The document is vary vague on authentication. The TLS spec unfortunatly give the idea it provides authentication. It does not. It provides proof of possesion of a key and provides information to enable the application to do authentication.
