### PR TITLE
Fragmentation #82 #85

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: martinthomson/i-d-template:latest
+    resource_class: small
     working_directory: ~/draft
 
     steps:
@@ -42,7 +43,7 @@ jobs:
       # Build txt and html versions of drafts
       - run:
           name: "Build Drafts"
-          command: "make 'CLONE_ARGS=--reference ~/git-reference'"
+          command: make
 
       # Update editor's copy on gh-pages
       - run:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# See http://editorconfig.org
+
+root = true
+
+[*.{md,xml,org}]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Automatically generated CODEOWNERS
+# Regenerate with `make update-codeowners`
+draft-ietf-tsvwg-dtls-over-sctp-bis.md magnus.westerlund@ericsson.com john.mattsson@ericsson.com claudio.porfiri@ericsson.com

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 0 * * 0,2,4'
   repository_dispatch:
     types: [archive]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -18,13 +19,13 @@ jobs:
       uses: martinthomson/i-d-template@v1
       with:
         make: archive
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
 
     - name: "Update GitHub Pages"
       uses: martinthomson/i-d-template@v1
       with:
         make: gh-archive
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
 
     - name: "Save Archive"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -32,7 +32,9 @@ jobs:
     - name: "Cache References"
       uses: actions/cache@v2
       with:
-        path: ${{ steps.cache-setup.outputs.path }}
+        path: |
+          ${{ steps.cache-setup.outputs.path }}
+          .targets.mk
         key: refcache-${{ steps.cache-setup.outputs.date }}
         restore-keys: |
           refcache-${{ steps.cache-setup.outputs.date }}
@@ -40,20 +42,19 @@ jobs:
 
     - name: "Build Drafts"
       uses: martinthomson/i-d-template@v1
+      with:
+        token: ${{ github.token }}
 
     - name: "Update GitHub Pages"
       uses: martinthomson/i-d-template@v1
       if: ${{ github.event_name == 'push' }}
       with:
         make: gh-pages
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
 
-    - name: "Save HTML"
+    - name: "Archive Built Drafts"
       uses: actions/upload-artifact@v2
       with:
-        path: "*.html"
-
-    - name: "Save Text"
-      uses: actions/upload-artifact@v2
-      with:
-        path: "*.txt"
+        path: |
+          draft-*.html
+          draft-*.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,9 @@ jobs:
     - name: "Cache References"
       uses: actions/cache@v2
       with:
-        path: ${{ steps.cache-setup.outputs.path }}
+        path: |
+          ${{ steps.cache-setup.outputs.path }}
+          .targets.mk
         key: refcache-${{ steps.date.outputs.date }}
         restore-keys: |
           refcache-${{ steps.date.outputs.date }}
@@ -35,8 +37,15 @@ jobs:
 
     - name: "Build Drafts"
       uses: martinthomson/i-d-template@v1
+      with:
+        token: ${{ github.token }}
 
     - name: "Upload to Datatracker"
       uses: martinthomson/i-d-template@v1
       with:
         make: upload
+
+    - name: "Archive Submitted Drafts"
+      uses: actions/upload-artifact@v2
+      with:
+        path: "draft-*-[0-9][0-9].xml"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,36 @@
+name: "Update generated files"
+# This rule is not run automatically.
+# It can be run manually to update all of the files that are part
+# of the template, specifically:
+#  - README.md
+#  - CONTRIBUTING.md
+#  - .note.xml
+#  - .github/CODEOWNERS
+#  - Makefile
+#
+#
+# This might be useful if you have:
+#  - added, removed, or renamed drafts (including after adoption)
+#  - added, removed, or changed draft editors
+#  - changed the title of drafts
+#
+# Note that this removes any customizations you have made to
+# the affected files.
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: "Update files"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Update generated files"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: update-files
+        token: ${{ github.token }}
+
+    - name: "Push Update"
+      run: git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *~
 /*-[0-9][0-9].xml
 archive.json
-draft-westerlund-tsvwg-dtls-over-sctp-bis.xml
+draft-ietf-tsvwg-dtls-over-sctp-bis.xml
 *.html
 lib
 *.pdf
@@ -14,5 +14,3 @@ report.xml
 *.txt
 *.upload
 venv/
-lib
-draft-westerlund-tsvwg-dtls-over-sctp-bis.xml

--- a/.note.xml
+++ b/.note.xml
@@ -1,7 +1,4 @@
 <note title="Discussion Venues" removeInRFC="true">
-<t>Discussion of this document takes place on the
-  TSVWG Working Group mailing list (tsvwg@ietf.org),
-  which is archived at <eref target="https://mailarchive.ietf.org/arch/browse/tsvwg/"/>.</t>
 <t>Source for this draft and an issue tracker can be found at
-  <eref target="https://github.com/gloinul/draft-westerlund-tsvwg-dtls-over-sctp-bis"/>.</t>
+    <eref target="https://github.com/gloinul/draft-westerlund-tsvwg-dtls-over-sctp-bis"/>.</t>
 </note>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,17 +15,3 @@ repository constitutes Contributions to the IETF Standards Process
 You agree to comply with all applicable IETF policies and procedures, including,
 BCP 78, 79, the TLP, and the TLP rules regarding code components (e.g. being
 subject to a Simplified BSD License) in Contributions.
-
-
-## Other Resources
-
-Discussion of this work occurs on the
-[tsvwg working group mailing list](https://mailarchive.ietf.org/arch/browse/tsvwg/)
-([subscribe](https://www.ietf.org/mailman/listinfo/tsvwg)).  In addition to
-contributions in GitHub, you are encouraged to participate in discussions there.
-
-**Note**: Some working groups adopt a policy whereby substantive discussion of
-technical issues needs to occur on the mailing list.
-
-You might also like to familiarize yourself with other
-[working group documents](https://datatracker.ietf.org/wg/tsvwg/documents/).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # Datagram Transport Layer Security (DTLS) over Stream Control Transmission Protocol (SCTP)
 
-This is the working area for the individual Internet-Draft, "Datagram Transport Layer Security (DTLS) over Stream Control Transmission Protocol (SCTP)".
+This is the working area for the IETF [TSVWG Working Group](https://datatracker.ietf.org/wg/tsvwg/documents/) Internet-Draft, "Datagram Transport Layer Security (DTLS) over Stream Control Transmission Protocol (SCTP)".
 
-* [Editor's Copy](https://gloinul.github.io/draft-westerlund-tsvwg-dtls-over-sctp-bis/#go.draft-westerlund-tsvwg-dtls-over-sctp-bis.html)
-* [Individual Draft](https://tools.ietf.org/html/draft-westerlund-tsvwg-dtls-over-sctp-bis)
-* [Compare Editor's Copy to Individual Draft](https://gloinul.github.io/draft-westerlund-tsvwg-dtls-over-sctp-bis/#go.draft-westerlund-tsvwg-dtls-over-sctp-bis.diff)
+* [Editor's Copy](https://gloinul.github.io/draft-westerlund-tsvwg-dtls-over-sctp-bis/#go.draft-ietf-tsvwg-dtls-over-sctp-bis.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-tsvwg-dtls-over-sctp-bis)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-dtls-over-sctp-bis)
+* [Compare Editor's Copy to Working Group Draft](https://gloinul.github.io/draft-westerlund-tsvwg-dtls-over-sctp-bis/#go.draft-ietf-tsvwg-dtls-over-sctp-bis.diff)
 
-## Building the Draft
+
+## Contributing
+
+See the
+[guidelines for contributions](https://github.com/gloinul/draft-westerlund-tsvwg-dtls-over-sctp-bis/blob/main/CONTRIBUTING.md).
+
+Contributions can be made by creating pull requests.
+The GitHub interface supports creating pull requests using the Edit (✏) button.
+
+
+## Command Line Usage
 
 Formatted text and HTML versions of the draft can be built using `make`.
 
@@ -14,11 +25,6 @@ Formatted text and HTML versions of the draft can be built using `make`.
 $ make
 ```
 
-This requires that you have the necessary software installed.  See
-[the instructions](https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md).
+Command line usage requires that you have the necessary software installed.  See
+[the instructions](https://github.com/martinthomson/i-d-template/blob/main/doc/SETUP.md).
 
-
-## Contributing
-
-See the
-[guidelines for contributions](https://github.com/gloinul/draft-westerlund-tsvwg-dtls-over-sctp-bis/blob/main/CONTRIBUTING.md).

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -410,8 +410,7 @@ ULP:  Upper Layer Protocol
    using DATA {{RFC4960}}, and optionally I-DATA {{RFC8260}} chunks.
 
    DTLS/SCTP works as a shim layer between the user message API and
-   SCTP. The fragmentation works similar as the DTLS fragmentation of
-   handshake messages.  On the sender side a user message fragmented
+   SCTP. On the sender side a user message is fragmented
    into fragments m0, m1, m2, each no larger than 2^14 = 16384
    bytes.
 
@@ -429,9 +428,17 @@ ULP:  Upper Layer Protocol
    The new user_message', i.e., the protected user message, is the input
    to SCTP.
 
-   On the receiving side DTLS is used to decrypt the individual
-   records. There are three failure cases an implementation needs to
-   detect and then act on:
+   On the receiving side, the length field in each DTLS record can be
+   used to determine the boundaries between DTLS records. DTLS can
+   decrypt individual records or a concatenated sequence of records.
+   The last DTLS record can be found by subtracting the length of
+   individual records from the length of user_message’. Whether to
+   decrypt individual records, sequences of records, or the whole
+   user_message’ is left to the implementation. The output from the
+   DTLS decryption(s) is the fragments m0, m1, m2 ... When all DTLS
+   records have been decrypted, the user_message is reassembled as
+   user_message = m0 | m1 | m2 ... There are three failure cases an
+   implementation needs to detect and then act on:
 
    1. Failure in decryption and integrity verification process of any
    DTLS record. Due to SCTP-AUTH preventing delivery of injected or
@@ -472,9 +479,9 @@ ULP:  Upper Layer Protocol
    The DTLS Connection ID MUST be negotiated
    ({{I-D.ietf-tls-dtls-connection-id}} or Section 9 of
    {{I-D.ietf-tls-dtls13}}). If DTLS 1.3 is used, the length field in
-   the record layer MUST be included. A 16-bit sequence number SHOULD
-   be used rather than 8-bit to minimize issues with DTLS record
-   sequence number wrapping.
+   the record layer MUST be included in all records. A 16-bit sequence
+   number SHOULD be used rather than 8-bit to minimize issues with DTLS
+   record sequence number wrapping.
 
    The ULP may use multiple messages simultanous, and the progress and
    delivery of these messages are progressing indepentely, thus the
@@ -1297,9 +1304,9 @@ this specification.
    Michael Tüxen, Eric Rescorla, and Robin Seggelmann.
 
    The RFC 6083 authors thanked Anna Brunstrom, Lars Eggert, Gorry
-   Fairhurst, Ian Goldberg, Alfred Hoenes, Carsten Hohendorf, Stefan
-   Lindskog, Daniel Mentz, and Sean Turner for their invaluable
-   comments.
+   Fairhurst, Ian Goldberg, Alfred Hoenes, Carsten Hohendorf, Daria
+   Ivanova, Stefan Lindskog, Daniel Mentz, Sean Turner, and Li Yan
+   for their invaluable comments.
 
    The authors of this document want to thank Daria Ivanova, Li Yan,
    and GitHub user vanrein for their contribution.

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -410,7 +410,7 @@ ULP:  Upper Layer Protocol
    using DATA {{RFC4960}}, and optionally I-DATA {{RFC8260}} chunks.
 
    DTLS/SCTP works as a shim layer between the user message API and
-   SCTP. On the sender side a user message is fragmented
+   SCTP. On the sender side a user message is split
    into fragments m0, m1, m2, each no larger than 2^14 = 16384
    bytes.
 

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -47,12 +47,11 @@ informative:
       -
         ins: Agence nationale de la sécurité des systèmes d'information
     date: August 2015
+
   TRISHAKE:
-    target: <https://hal.inria.fr/hal-01102259/file/triple-handshakes-and-cookie-cutters-oakland14.pdf>
-    title:
-       Triple Handshakes and Cookie Cutters: Breaking and Fixing Authentication over TLS
-    seriesinfo:
-      IEEE Symposium on Security & Privacy
+    target: "https://hal.inria.fr/hal-01102259/file/triple-handshakes-and-cookie-cutters-oakland14.pdf"
+    title: "Triple Handshakes and Cookie Cutters: Breaking and Fixing Authentication over TLS"
+    seriesinfo: "IEEE Symposium on Security & Privacy"
     author:
       -
         ins: K. Bhargavan

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -726,14 +726,14 @@ ULP:  Upper Layer Protocol
 ## Renegotiation and KeyUpdate
 
    DTLS 1.2 renegotiation enables rekeying (with ephemeral Diffie-
-   Hellman) of DTLS as well as mutual reauthentication and transfer
-	of revocation information inside an DTLS
-   1.2 connection. Renegotiation has been removed from DTLS 1.3 and
-   partly replaced with post-handshake messages such as KeyUpdate. The
-   parallel DTLS connection solution was specified due to lack of
-   necessary features with DTLS 1.3 considered needed for long lived
-   SCTP associations, such as rekeying (with ephemeral Diffie-Hellman)
-   as well as mutual reauthentication.
+   Hellman) of DTLS as well as mutual reauthentication and transfer of
+   revocation information inside an DTLS 1.2 connection. Renegotiation
+   has been removed from DTLS 1.3 and partly replaced with
+   post-handshake messages such as KeyUpdate. The parallel DTLS
+   connection solution was specified due to lack of necessary features
+   with DTLS 1.3 considered needed for long lived SCTP associations,
+   such as rekeying (with ephemeral Diffie-Hellman) as well as mutual
+   reauthentication.
 
    This specification do not allow usage of DTLS 1.2 renegotiation to
    avoid race conditions and corner cases in the interaction between
@@ -1155,7 +1155,7 @@ this specification.
    including data encrypted with
    application_traffic_secret_N+1, application_traffic_secret_N+2,
    etc. Note that KeyUpdate does not update the exporter_secret.
-   
+
    DTLS/SCTP is in many deployments replacing IPsec. For IPsec, NIST
    (US), BSI (Germany), and ANSSI (France) recommends very frequent
    re-run of Diffie-Hellman to provide forward secrecy and

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -1302,8 +1302,8 @@ this specification.
    Lindskog, Daniel Mentz, and Sean Turner for their invaluable
    comments.
 
-   The authors of this document want to thank GitHub user vanrein for
-   their contribution.
+   The authors of this document want to thank Daria Ivanova, Li Yan,
+   and GitHub user vanrein for their contribution.
 
 --- back
 

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -1304,9 +1304,8 @@ this specification.
    Michael Tüxen, Eric Rescorla, and Robin Seggelmann.
 
    The RFC 6083 authors thanked Anna Brunstrom, Lars Eggert, Gorry
-   Fairhurst, Ian Goldberg, Alfred Hoenes, Carsten Hohendorf, Daria
-   Ivanova, Stefan Lindskog, Daniel Mentz, Sean Turner, and Li Yan
-   for their invaluable comments.
+   Fairhurst, Ian Goldberg, Alfred Hoenes, Carsten Hohendorf, Stefan 
+   Lindskog, Daniel Mentz, and Sean Turner for their invaluable comments.
 
    The authors of this document want to thank Daria Ivanova, Li Yan,
    and GitHub user vanrein for their contribution.


### PR DESCRIPTION
Fragmentation #82 #85

- Added information on decryption and reassembly based on the comments and suggestion from Li Yan. This is very good information to have. I changed the suggested text a bit. I tried to use some sentences from the DTLS 1.3 draft. There is also not a single way to do this. Some things are up to the implementation. #82 

- Removed the sentence that records are decrypted individually. This is up to the implementation. Might input the whole user_message' to DTLS. DTLS can handle sequences of concatenated records. #82 

- Removed the comparision with DTLS handshake fragmentation based on a comment from Daria Ivanova. While there are similarities there are also a lot of differences. The comparision does not really help and likely just cause confusion. #85

- Added Li Yan and Daria Ivanova to the Acknowledgments section