### PR TITLE
Stream usage bug fix

### DIFF
--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -545,10 +545,10 @@ This update that replaces RFC 6083 defines the following changes:
    As it is required to establish the DTLS connection at the beginning
    of the SCTP association, either of the peers should never send any
    SCTP user messages that are not protected by DTLS. So, the case
-   that an endpoint receives data that is not either DTLS messages on
-   Stream 0 or protected user messages in the form of a sequence of
-   DTLS Records on any stream is a protocol violation. The receiver
-   MAY terminate the SCTP association due to this protocol
+   that an endpoint receives data that is not either DTLS messages or
+   protected user messages in the form of a sequence of DTLS Records
+   on any stream is a protocol violation. The receiver MAY terminate
+   the SCTP association due to this protocol
    violation. Implementations that does not have a DTLS endpoint
    immediately ready on SCTP handshake completion will have to ensure
    correct caching of the messages until the DTLS endpoint is ready.

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -594,7 +594,10 @@ This update that replaces RFC 6083 defines the following changes:
    messages. Thus, it is allowed to insert between protected user
    message fragments DTLS records of other types as the DTLS receiver
    will process these and not result in any user message data being
-   inserted into the ULP's user message.
+   inserted into the ULP's user message. However, DTLS messages of
+   other types than protected user message MUST be sent reliable, so
+   the DTLS record can only be interleaved in case the ULP user
+   message is sent as reliable.
 
    DTLS is capable of handling reordering of the DTLS
    records. However, depending on stream properties and which user


### PR DESCRIPTION
When updating the text on stream usage an important aspect was lost, namely that DTLS messages that are not ULP data needs to be sent reliably. 