### PR TITLE
Issue #182 - AEAD limits

### DIFF
--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -528,16 +528,8 @@ terminated and the associated keying material discarded.
    for SCTP where the previous epoch’s security context is maintained
    and thus changes to epoch handling would be necessary.
 
-### DTLS 1.2 Considerations
-
-   The endpoint MUST NOT use DTLS 1.2 renegotiation. The
-   endpoint MUST instead initiate a new DTLS connection before the old
-   one reaches the used cipher suit's key life time. The AEAD limits given
-   in section 4.5.3 of {{RFC9147}} SHOULD be followed.
-
-### DTLS 1.3 Considerations
-
-   The DTLS 1.3 endpoint MUST NOT send any KeyUpdate message. The
+   A DTLS 1.2 endpoint MUST NOT use renegotiation and a DTLS 1.3 endpoint
+   MUST NOT send any KeyUpdate message. The
    endpoint MUST instead initiate a new DTLS connection before the old
    one reaches the used cipher suit's key life time. The AEAD limits given
    in section 4.5.3 of {{RFC9147}} SHOULD be followed.

--- a/draft-ietf-tsvwg-dtls-over-sctp-bis.md
+++ b/draft-ietf-tsvwg-dtls-over-sctp-bis.md
@@ -363,7 +363,7 @@ terminated and the associated keying material discarded.
    DTLS 1.3 comes with a large number of significant changes.
 
    *  Renegotiations are not supported and instead partly replaced by
-      KeyUpdates. The number of KeyUpdates is limited to 2<sup>48</sup>.
+      key updates. The number of key updates is limited to 2<sup>48</sup>.
 
    *  Strict AEAD significantly limits on how much many packets can be
       sent before rekeying.
@@ -530,13 +530,17 @@ terminated and the associated keying material discarded.
 
 ### DTLS 1.2 Considerations
 
-   The endpoint MUST NOT use DTLS 1.2 renegotiation.
+   The endpoint MUST NOT use DTLS 1.2 renegotiation. The
+   endpoint MUST instead initiate a new DTLS connection before the old
+   one reaches the used cipher suit's key life time. The AEAD limits given
+   in section 4.5.3 of {{RFC9147}} SHOULD be followed.
 
 ### DTLS 1.3 Considerations
 
    The DTLS 1.3 endpoint MUST NOT send any KeyUpdate message. The
    endpoint MUST instead initiate a new DTLS connection before the old
-   one reaches the used cipher suit's key life time.
+   one reaches the used cipher suit's key life time. The AEAD limits given
+   in section 4.5.3 of {{RFC9147}} SHOULD be followed.
 
 ## DTLS Connection Identifier
 


### PR DESCRIPTION
key limits was already mentioned. But not explicitly AEAD limits. As we are specifying a new mechanism (parallel connection) I think it makes sense to put the same requirements on DTLS 1.2 and DTLS 1.3. This simplifies implementation.